### PR TITLE
Issue: #SB-16819 fix: FIXED: testcases for getEnrolledCourse(), ADDED…

### DIFF
--- a/src/course/def/course-service.ts
+++ b/src/course/def/course-service.ts
@@ -45,7 +45,7 @@ export interface CourseService {
     /** @internal */
     resetCapturedAssessmentEvents();
 
-    syncAssessmentEvents(): Observable<undefined>;
+    syncAssessmentEvents(options?: {persistedOnly: boolean}): Observable<undefined>;
 
     generateAssessmentAttemptId(request: GenerateAttemptIdRequest): string;
 }

--- a/src/course/impl/course-service-impl.ts
+++ b/src/course/impl/course-service-impl.ts
@@ -358,10 +358,14 @@ export class CourseServiceImpl implements CourseService {
         this.capturedAssessmentEvents[key]!.push(event);
     }
 
-    public syncAssessmentEvents(): Observable<undefined> {
-        const capturedAssessmentEvents = this.capturedAssessmentEvents;
+    public syncAssessmentEvents(options = { persistedOnly: false }): Observable<undefined> {
+        let capturedAssessmentEvents = {};
 
-        this.resetCapturedAssessmentEvents();
+        if (!options.persistedOnly) {
+            capturedAssessmentEvents = this.capturedAssessmentEvents;
+
+            this.resetCapturedAssessmentEvents();
+        }
 
         return this.syncAssessmentEventsHandler.handle(
             capturedAssessmentEvents

--- a/src/telemetry/util/telemetry-auto-sync-service-impl.spec.ts
+++ b/src/telemetry/util/telemetry-auto-sync-service-impl.spec.ts
@@ -178,7 +178,7 @@ describe('TelemetryAutoSyncServiceImpl', () => {
                 jest.useRealTimers();
 
                 setTimeout(() => {
-                    expect(mockCourseService.syncAssessmentEvents).toHaveBeenCalled();
+                    expect(mockCourseService.syncAssessmentEvents).toHaveBeenCalledWith(expect.objectContaining({ persistedOnly: true }));
                     expect(mockUpdateContentState).toHaveBeenCalled();
                     done();
                 });

--- a/src/telemetry/util/telemetry-auto-sync-service-impl.ts
+++ b/src/telemetry/util/telemetry-auto-sync-service-impl.ts
@@ -129,7 +129,7 @@ export class TelemetryAutoSyncServiceImpl implements TelemetryAutoSyncService {
         }
 
         await zip(
-            this.courseService.syncAssessmentEvents(),
+            this.courseService.syncAssessmentEvents({ persistedOnly: true }),
             new ContentStatesSyncHandler(
                 new UpdateContentStateApiHandler(this.apiService, this.sdkConfig.courseServiceConfig),
                 this.dbService, this.sharedPreferences, this.keyValueStore


### PR DESCRIPTION
…: option persistedOnly for syncAssessmentEvents() to be used with telemetry-auto-sync-service-impl